### PR TITLE
Tweak Dockerfile so it will still work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,18 @@
 FROM debian:wheezy-20190228-slim
+ENV DEBIAN_FRONTEND=noninteractive
 RUN mkdir -p /usr/share/man/man1 && \
     echo "deb http://archive.debian.org/debian wheezy main contrib non-free" > /etc/apt/sources.list && \
     apt-get update && \
-    apt-get -yu dist-upgrade && \
-    apt-get -y --force-yes install tzdata=2016d-0+deb7u1 && \
-    DEBIAN_FRONTEND=noninteractive apt-get -y install x11vnc xvfb jwm iceweasel openjdk-6-jre tzdata-java icedtea-6-plugin icedtea-netx && \
+    apt-get --assume-yes --force-yes --show-upgraded dist-upgrade && \
+    apt-get --assume-yes --force-yes install tzdata=2016d-0+deb7u1 && \
+    apt-get --assume-yes --force-yes install x11vnc xvfb jwm iceweasel openjdk-6-jre tzdata-java icedtea-6-plugin icedtea-netx && \
     update-alternatives --set javaws /usr/lib/jvm/java-6-openjdk-amd64/jre/bin/javaws && \
-    apt-get -y autoremove && \
+    apt-get --assume-yes --force-yes autoremove && \
     apt-get clean && \
-    rm -rf /var/lib/{apt,dpkg,cache,log}
-RUN mkdir ~/.vnc && \
+    rm -rf /var/lib/{apt,dpkg,cache,log} && \
+    mkdir ~/.vnc && \
     echo "exec jwm &" >> ~/.xinitrc && \
     echo "firefox" >> ~/.xinitrc && \
     chmod 755 ~/.xinitrc
-ENTRYPOINT ["/usr/bin/x11vnc", "-forever", "-create"]
+ENTRYPOINT ["/usr/bin/x11vnc", "-nopw", "-forever", "-create"]
+CMD ["-geometry", "1024x768"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,11 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN mkdir -p /usr/share/man/man1 && \
     echo "deb http://archive.debian.org/debian wheezy main contrib non-free" > /etc/apt/sources.list && \
     apt-get update && \
-    apt-get --assume-yes --force-yes --show-upgraded dist-upgrade && \
-    apt-get --assume-yes --force-yes install tzdata=2016d-0+deb7u1 && \
-    apt-get --assume-yes --force-yes install x11vnc xvfb jwm iceweasel openjdk-6-jre tzdata-java icedtea-6-plugin icedtea-netx && \
+    apt-get -yu --force-yes dist-upgrade && \
+    apt-get -y --force-yes install tzdata=2016d-0+deb7u1 && \
+    apt-get -y --force-yes install x11vnc xvfb jwm iceweasel openjdk-6-jre tzdata-java icedtea-6-plugin icedtea-netx && \
     update-alternatives --set javaws /usr/lib/jvm/java-6-openjdk-amd64/jre/bin/javaws && \
-    apt-get --assume-yes --force-yes autoremove && \
+    apt-get -y --force-yes autoremove && \
     apt-get clean && \
     rm -rf /var/lib/{apt,dpkg,cache,log} && \
     mkdir ~/.vnc && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:wheezy-20190228-slim
-ENV DEBIAN_FRONTEND=noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
 RUN mkdir -p /usr/share/man/man1 && \
     echo "deb http://archive.debian.org/debian wheezy main contrib non-free" > /etc/apt/sources.list && \
     apt-get update && \

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ This will start a container:
 
 Now you can access Firefox with any VNC client opening localhost on standard port 5900.
 
+### Setting the Geometry
+
+By default the `-geometry` option is set to `1024x768`, if you want to override that you can add that as a command after container name:
+
+    $ docker run -d --rm -p 5900:5900 --name firefox-java-vnc mablanco/firefox-java-vnc -geometry 960x640
+
+> NOTE: According the the [documentation](https://github.com/LibVNC/x11vnc/blob/master/doc/OPTIONS.md) `-geometry` and `-scale` are the same option "-geometry WxH: Same as -scale WxH"
+
 ## Troubleshooting
 
 If the container starts and then dies without notice, follow these steps to try to debug the problem:


### PR DESCRIPTION
Thanks for this project! It allowed us to access some ancient hardware we still had running.

I thought I would see if I could do a fresh build, but it was failing. So I added the flags it was complaining about, moved the DEBIAN_FRONTEND to ENV, and added a `-geometry` flag to the CMD (which can be overridden by the docker run/compose of course). I also switched to the long flags for the apt commands, just for easier reference as to what they do.

Feel free to remove what you don't see as useful 👍 